### PR TITLE
remove-uneeded gulp-cli dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "gulp-accessibility": "^1.2.1",
     "gulp-autoprefixer": "^2.2.0",
     "gulp-changed": "^1.2.1",
-    "gulp-cli": "git://github.com/gulpjs/gulp-cli#4.0",
     "gulp-concat": "^2.5.2",
     "gulp-css-globbing": "^0.1.7",
     "gulp-data": "^1.2.0",


### PR DESCRIPTION
was missed when merging the skeleton